### PR TITLE
Add extract_desktop

### DIFF
--- a/babelglade/extract.py
+++ b/babelglade/extract.py
@@ -32,3 +32,34 @@ def extract_glade(fileobj, keywords, comment_tags, options):
                 comment = [elem.get("comments")]
             to_translate.append([line_no, func_name, message, comment])
     return to_translate
+
+
+# All localestrings from https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s05.html
+TRANSLATABLE = (
+    'Name',
+    'GenericName',
+    'Comment',
+    'Icon',
+    'Keywords',
+)
+
+
+def extract_desktop(fileobj, keywords, comment_tags, options):
+    for lineno, line in enumerate(fileobj, 1):
+        if line.startswith(b'[Desktop Entry]'):
+            continue
+
+        for t in TRANSLATABLE:
+            if not line.startswith(t.encode('utf-8')):
+                continue
+            else:
+                l = line.decode('utf-8')
+                comments = []
+                key_value = l.split('=', 1)
+                key, value = key_value[0:2]
+
+                funcname = key # FIXME: Why can I not assign that name to funcname?
+                funcname = ''
+                message = value
+                comments.append(key)
+                yield (lineno, funcname, message.strip(), comments)

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     entry_points = """
     [babel.extractors]
     glade = babelglade.extract:extract_glade
+    desktop = babelglade.extract:extract_desktop
 
     [distutils.commands]
     compile_catalog = babel.messages.frontend:compile_catalog


### PR DESCRIPTION
Add the ability to also extract translatable strings from
the desktop file.
This function is the same that was also available here
https://github.com/gnome-keysign/gnome-keysign/blob/126f9c7faa3068171a3645bd3e53f95e2ea76117/babelglade/__init__.py#L32