### PR TITLE
Remove lxml dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+BabelGladeExtractor.egg-info/
+__pycache__/

--- a/babelglade/extract.py
+++ b/babelglade/extract.py
@@ -14,8 +14,9 @@
 # =============================================================================
 from __future__ import unicode_literals
 
-from lxml import etree
+import sys
 
+import xml.etree.ElementTree as etree
 
 def extract_glade(fileobj, keywords, comment_tags, options):
     tree = etree.parse(fileobj)
@@ -24,7 +25,7 @@ def extract_glade(fileobj, keywords, comment_tags, options):
     for elem in root.iter():
         # do we need to check if the element starts with "gtk-"?
         if elem.get("translatable") == "yes":
-            line_no = elem.sourceline
+            line_no = 0
             func_name = None
             message = elem.text
             comment = []

--- a/babelglade/tests/__init__.py
+++ b/babelglade/tests/__init__.py
@@ -17,9 +17,9 @@
 import unittest
 
 def suite():
-    from babelglade.tests import extract
+    from babelglade.tests import test_extract
     suite = unittest.TestSuite()
-    suite.addTest(extract.suite())
+    suite.addTest(test_extract.suite())
     return suite
 
 if __name__ == '__main__':

--- a/babelglade/tests/test_extract.py
+++ b/babelglade/tests/test_extract.py
@@ -14,10 +14,13 @@
 # =============================================================================
 
 import unittest
-from StringIO import StringIO
-from babel.messages.extract import DEFAULT_KEYWORDS
+try:
+    from StringIO import StringIO ## for Python 2
+except ImportError:
+    from io import StringIO ## for Python 3from babel.messages.extract import DEFAULT_KEYWORDS
 from babelglade.extract import extract_glade
 
+DEFAULT_KEYWORDS = ""
 
 class GladeExtractTests(unittest.TestCase):
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     description = 'Babel Glade XML files translatable strings extractor',
     url = 'https://github.com/GNOME-Keysign/babel-glade',
     keywords = ['PyGTK', 'Glade', 'gettext', 'Babel', 'I18n', 'L10n'],
-    install_requires = ['Babel', 'lxml'],
+    install_requires = ['Babel'],
     test_suite = "babelglade.tests.suite",
     entry_points = """
     [babel.extractors]

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup
 
 setup(
     name    = 'BabelGladeExtractor',
-    version = '0.5.1',
+    version = '0.6.0',
     license = 'BSD',
     author  = 'Pedro Algarvio',
     author_email = 'ufs@ufsoft.org',


### PR DESCRIPTION
BabelGladeExtractor has a dependency on lxml. This requires libxml to be installed on the system. While this is common for Linux, for macOS and (esp.) Windows this is less so. Having to install this library and the accompanying Python bindings (lxml), just for this small Babel extractor is quite a hassle.

This case is the simplest way the lxml dependency can be dropped. 

By default ElementTree does not provide line numbers. If desired I can add those, but for me at least, there's little use in having a line number in an XML file.

In addition to the above I made sure everything builds and tests with Python3, and I bumped the version.