### PR TITLE
sort pofiles before processing

### DIFF
--- a/babelglade/translate.py
+++ b/babelglade/translate.py
@@ -80,9 +80,9 @@ def translate_appdata_file(infile, outfile, localedir):
 def get_catalogs(localedir):
     # glob in Python 3.5 takes ** syntax
     # pofiles = glob.glob(os.path.join(localedir, '**.po', recursive=True))
-    pofiles = [os.path.join(dirpath, f)
+    pofiles = sorted([os.path.join(dirpath, f)
                for dirpath, dirnames, files in os.walk(localedir)
-               for f in files if f.endswith('.po')]
+               for f in files if f.endswith('.po')])
     logging.debug('Loading %r', pofiles)
     catalogs = {}
 


### PR DESCRIPTION
This PR adds simple sorting to the list of inputs for processing. Not sorting this list will leave them in the order as delivered by `os.walk()`, which may not be deterministic, breaking reproducible builds.