### PR TITLE
Make tests part of the distro

### DIFF
--- a/babelglade/tests/__init__.py
+++ b/babelglade/tests/__init__.py
@@ -17,9 +17,10 @@
 import unittest
 
 def suite():
-    from babelglade.tests import test_extract
+    from babelglade.tests import test_extract, test_translate
     suite = unittest.TestSuite()
-    suite.addTest(test_extract.suite())
+    suite.addTest(unittest.makeSuite(test_extract.GladeExtractTests))
+    suite.addTest(unittest.makeSuite(test_translate.TranslateTestCase))
     return suite
 
 if __name__ == '__main__':

--- a/babelglade/tests/test_extract.py
+++ b/babelglade/tests/test_extract.py
@@ -69,9 +69,3 @@ class GladeExtractTests(unittest.TestCase):
         extracted = extract_glade(self.glade_fileobj, DEFAULT_KEYWORDS, False, {})
         for entry in list(extracted):
             assert len(entry) == 4, "extract_galde did not return a 4 tupple item"
-
-
-def suite():
-    suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(GladeExtractTests))
-    return suite

--- a/babelglade/tests/test_translate.py
+++ b/babelglade/tests/test_translate.py
@@ -1,39 +1,42 @@
 
 import os
+import unittest
 from babelglade.translate import translate_desktop_file, translate_appdata_file
 
 def relative(test_file):
     return os.path.join(os.path.dirname(__file__), test_file)
 
 
-def test_desktop_file():
-    translate_desktop_file(relative("test.raw.desktop"), "test.desktop", relative("locale"))
+class TranslateTestCase(unittest.TestCase):
 
-    with open("test.desktop") as desktop:
-        content = desktop.read()
+    def test_desktop_file(self):
+        translate_desktop_file(relative("test.raw.desktop"), "test.desktop", relative("locale"))
 
-    assert "Comment=This should be translated." in content
-    assert "Comment[nl]=Dit moet worden vertaald." in content
-    assert "Comment[fr]=Cela devrait être traduit." in content
+        with open("test.desktop") as desktop:
+            content = desktop.read()
 
-def test_appdata_xml():
-    translate_appdata_file(relative("test.raw.appdata.xml"), "test.appdata.xml", relative("locale"))
+        assert "Comment=This should be translated." in content
+        assert "Comment[nl]=Dit moet worden vertaald." in content
+        assert "Comment[fr]=Cela devrait être traduit." in content
 
-    with open("test.appdata.xml") as desktop:
-        content = desktop.read()
+    def test_appdata_xml(self):
+        translate_appdata_file(relative("test.raw.appdata.xml"), "test.appdata.xml", relative("locale"))
 
-    assert "<p>This should be translated.</p>" in content
-    assert '<p xml:lang="fr">Cela devrait être traduit.</p>' in content
-    assert '<p xml:lang="nl">Dit moet worden vertaald.</p>' in content
-    assert """<p>
+        with open("test.appdata.xml") as desktop:
+            content = desktop.read()
+
+        assert "<p>This should be translated.</p>" in content
+        assert '<p xml:lang="fr">Cela devrait être traduit.</p>' in content
+        assert '<p xml:lang="nl">Dit moet worden vertaald.</p>' in content
+        assert """<p>
       Multi line
       text.
     </p>""" in content
-    assert """<p xml:lang="fr">
+        assert """<p xml:lang="fr">
       Texte
       multi-ligne.
     </p>""" in content
-    assert """<p xml:lang="nl">
+        assert """<p xml:lang="nl">
       Meerregelige
       tekst.
     </p>""" in content

--- a/babelglade/translate.py
+++ b/babelglade/translate.py
@@ -48,6 +48,9 @@ def translate_desktop_file(infile, outfile, localedir):
         # First the original line found it in the file, then the translations.
         outfp.writelines((outline+'\n' for outline in ([line] + additional_lines)))
 
+    infp.close()
+    outfp.close()
+
 
 def translate_appdata_file(infile, outfile, localedir):
     catalogs = get_catalogs(localedir)
@@ -94,7 +97,8 @@ def get_catalogs(localedir):
     catalogs = {}
 
     for pofile in pofiles:
-        catalog = read_po(open(pofile, 'r'))
+        with open(pofile, 'r') as f:
+            catalog = read_po(f)
         catalogs[catalog.locale] = catalog
         logging.info("Found %d strings for %s", len(catalog), catalog.locale)
         # logging.debug("Strings for %r", catalog, catalog.values())

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,6 @@ setup(
     [distutils.commands]
     compile_catalog = babel.messages.frontend:compile_catalog
     """,
-    packages = ['babelglade']
+    packages = ['babelglade', 'babelglade.tests']
 
 )


### PR DESCRIPTION
Tests are not bundled, although they are referenced from `setup.py`. That caused some trouble (see #5). This PR adds the tests to te distro.

Since I created the `translate` tests using PyTest. Those are nowconverted to Unittest, so they are run as well. This revealed a resource leak, which is now fixed.

Fixes #5.