### PR TITLE
extract_glade: add linenos, context, GtkBuilder

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include babelglade/tests/test.raw.*
+include babelglade/tests/test_extract.*
 recursive-include babelglade/tests/locale *

--- a/babelglade/extract.py
+++ b/babelglade/extract.py
@@ -14,25 +14,72 @@
 # =============================================================================
 from __future__ import unicode_literals
 
-import sys
-
 import xml.etree.ElementTree as etree
 
+
 def extract_glade(fileobj, keywords, comment_tags, options):
-    tree = etree.parse(fileobj)
-    root = tree.getroot()
-    to_translate = []
-    for elem in root.iter():
-        # do we need to check if the element starts with "gtk-"?
-        if elem.get("translatable") == "yes":
-            line_no = 0
+    """Extracts translatable strings from Glade files or GtkBuilder UI XML.
+
+    :param fileobj: the file-like object to extract from, iterable by lines
+    :param keywords: a list of translation keywords to extract, with the same
+        names and meanings as C/Python i18n function names.
+    :param comment_tags: a list of translator tags to search for and
+        include in the results. This is ignored.
+    :param options: a dictionary of additional options (optional)
+    :return: An iterator over ``(lineno, funcname, message, comments)``
+        tuples whose interpretation depends on ``funcname``.
+    :rtype: iterator
+
+    Properties must be marked translatable="yes". Context and comments
+    attributes are respected. The yielded tuples are and returned as if
+    you used gettext() or pgettext() in C or Python code. In other
+    words, "gettext" or "pgettext" must be listed in ``keywords`` for
+    contextless or context-bearing strings to be translated. The
+    shorthand "_" and "C_" aliases from g18n.h are valid keywords too.
+
+    Babel defaults to having "gettext" and "pgettext" in ``keywords``,
+    so you don't normally need to worry about this.
+
+    See also:
+
+    * babel.messages.extract.extract()
+    * http://babel.pocoo.org/en/latest/messages.html#writing-extraction-methods
+    * https://www.gnu.org/software/gettext/manual/html_node/PO-Files.html
+
+    """
+    parser = etree.XMLPullParser(["end"])
+    pgettext_wanted = ("pgettext" in keywords) or ("C_" in keywords)
+    gettext_wanted = "gettext" in keywords
+    truthy_values = [s.casefold() for s in ["yes", "true", "1", "y", "t"]]
+    for line_idx, line_data in enumerate(fileobj):
+        parser.feed(line_data)
+        for event, elem in parser.read_events():
+            assert event == "end"
+            translatable_attr = elem.attrib.get("translatable", "no")
+            if not translatable_attr.casefold() in truthy_values:
+                continue
+
+            comments = []
+            if "comments" in elem.attrib:
+                comments.append(elem.attrib["comments"])
+
+            # Babel's interpretation of the yielded tuple depends on the
+            # function name returned as part of it. This tells Babel what
+            # the elements of the returned messages list or tuple mean.
             func_name = None
-            message = elem.text
-            comment = []
-            if elem.get("comments"):
-                comment = [elem.get("comments")]
-            to_translate.append([line_no, func_name, message, comment])
-    return to_translate
+            if "context" in elem.attrib and pgettext_wanted:
+                func_name = "pgettext"
+                context = elem.attrib["context"]
+                messages = [context, elem.text]
+            elif gettext_wanted and "context" not in elem.attrib:
+                # Returned strings are equivalent to a list or tuple
+                # of length 1, like the arguments to C gettext()/_().
+                func_name = "gettext"
+                messages = elem.text
+
+            if func_name is None:
+                continue
+            yield (line_idx + 1, func_name, messages, comments)
 
 
 # All localestrings from https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s05.html

--- a/babelglade/tests/test_extract.glade2.xml
+++ b/babelglade/tests/test_extract.glade2.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE glade-interface SYSTEM "glade-2.0.dtd">
+<glade-interface>
+  <widget class="GtkWindow" id="window1">
+    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+    <child>
+      <widget class="GtkVBox" id="vbox1">
+        <property name="visible">True</property>
+        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+        <child>
+          <widget class="GtkLabel" id="label1">
+            <property name="visible">True</property>
+            <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+            <property name="label" translatable="yes" comments="A label with translator comments">This is a Label</property>
+          </widget>
+        </child>
+        <child>
+          <widget class="GtkButton" id="button1">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+            <property name="label" translatable="yes" comments="This button also includes translator comments">A button</property>
+          </widget>
+          <packing>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </widget>
+    </child>
+  </widget>
+</glade-interface>

--- a/babelglade/tests/test_extract.gtkbuilder.xml
+++ b/babelglade/tests/test_extract.gtkbuilder.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <object class="GtkWindow" id="window1">
+    <property name="can_focus">False</property>
+    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+    <child>
+      <placeholder/>
+    </child>
+    <child>
+      <object class="GtkVBox" id="vbox1">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+        <child>
+          <object class="GtkLabel" id="label1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+            <property name="label" translatable="yes" context="the first label" comments="A label with translator comments">This is a Label</property>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="label2">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+            <property name="label" translatable="yes" context="the second label">This is a Label</property>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="button1">
+            <property name="label" translatable="yes" comments="This button also includes translator comments">A button</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ for routine i18n lifecycle tasks.
 
 """,
     url = 'https://github.com/GNOME-Keysign/babel-glade',
-    keywords = ['PyGTK', 'PyGObject', 'Glade', '', 'gettext', 'Babel', 'I18n', 'L10n'],
+    keywords = ['PyGTK', 'PyGObject', 'Glade', 'GtkBuilder', 'gettext', 'Babel', 'I18n', 'L10n'],
     install_requires = ['Babel'],
     test_suite = "babelglade.tests.suite",
     entry_points = """

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,30 @@ setup(
     author_email = 'ufs@ufsoft.org',
     maintainer = 'Tobias Mueller',
     maintainer_email = 'tobiasmue@gnome.org',
-    description = 'Babel Glade XML files translatable strings extractor',
+    description = 'Babel l10n support for Glade, GtkBuilder, and .desktop files',
+    long_description = """
+This package contains message catalog extractors for the following
+formats, extending Babel_ so it can handle them.
+
+    * The older "Glade v2" XML format;
+    * The new GtkBuilder-compatible "UI Definition XML" format used by
+      Glade_ 3.8 and above;
+    * The AppData XML dialect, because it's similar;
+    * FreeDesktop.org ".desktop" files.
+
+To make these formats translatable, install this package. Then in your
+own projects map some source and data files to the simple extractor
+names "glade" and "desktop" that are provided by this package. You can
+then use Babel's setuptools integration or its command line interface
+for routine i18n lifecycle tasks.
+
+.. _Babel: http://babel.pocoo.org/en/latest/index.html
+.. _Glade: https://glade.gnome.org/
+
+
+""",
     url = 'https://github.com/GNOME-Keysign/babel-glade',
-    keywords = ['PyGTK', 'Glade', 'gettext', 'Babel', 'I18n', 'L10n'],
+    keywords = ['PyGTK', 'PyGObject', 'Glade', '', 'gettext', 'Babel', 'I18n', 'L10n'],
     install_requires = ['Babel'],
     test_suite = "babelglade.tests.suite",
     entry_points = """


### PR DESCRIPTION
Hello, lovely Babel+Glade integrators.

I was missing line number support. More importantly for my apps, I noticed that i18n contexts in Glade/GtkBuilder "UI Definition" XML files weren't supported. I hope you're willing to accept this patch. It tests clean with `python3 setup.py test`, and adds a bunch of tests for the new corner cases. It adds:

* Support for line numbers in the source XML files, so that online tools like weblate can tie it back to the source. Sometimes this isn't particularly helpful, but modern Glade happens to write quite prettily formatted XML.
* Support for i18n context fields in the source XML, as written by Glade 3.22.
* Some improved documentation.
* Tested, declared support for the newer GtkBuilder XML format, as written by Glade 3.0+.

It is safely pip3-installable, and appears to get the job done when installed.

Thank you for creating and maintaining these extractors. Please let me know if you need any further explanation of this commit, or if you need any changes to it before you can accept it.