### PR TITLE
Update documents, expand README for PyPi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,73 @@
+# BabelGladeExtractor
+
+This package contains message catalog extractors for the following
+formats, extending [Babel][babel] so it can handle them.
+
+* The new XML format used by [Glade][glade] 3.8 and above, properly
+  known as the [GtkBuilder UI Definitions][uixml] format;
+
+* The older "GladeXML" format used by libglade and older versions of
+  Glade;
+
+* The GNOME [AppData XML][appdataxml] dialect, because it's similar;
+
+* FreeDesktop.org [Desktop Entry][desktopfile] files.
+
+## Getting started
+
+To make these formats translatable, install this package using pip:
+
+```shell
+pip3 install BabelGladeExtractor
+```
+
+Then in your own projects, map some source and data files to the simple
+extractor names "glade" and "desktop" that are provided by this package.
+In your `setup.py`, add a section like
+
+```ini
+[extract_messages]
+mapping_file = babel.cfg
+output_file = subdir/myproject.pot
+input_dirs = .
+```
+
+Next, create a separate `babel.cfg` file, and add sections to it for
+each format you want to translate.
+
+```ini
+[glade: **.ui]
+
+[desktop: **.desktop]
+
+```
+
+You can then use Babel's [setuptools integration][babelsetuptools] or
+its [command line interface][babelcli] for your routine i18n lifecycle
+tasks.
+
+```shell
+python3 setup.py extract_messages
+```
+
+There's a lot more to it than this, naturally. See Babel's extensive
+[Working with Message Catalogs][babelpo] documentation for a detailed
+explanation of how to get translatable strings into your Python code.
+
+In Glade 3.22, when you are editing a string property in a sidebar,
+click the edit icon on the right hand side of the text entry. In the
+dialog that pops up, enter the text in the main text box, and make sure
+that the Translatable checkbox is ticked. You can also add some helpful
+[context][pocontext] or comments for your translators if you need to
+give them a hint. BabelGladeExtractor will handle the corresponding XML
+attributes appropriately when it extracts strings for translation.
+
+[babel]: http://babel.pocoo.org/
+[glade]: https://glade.gnome.org/
+[uixml]: https://developer.gnome.org/gtk3/stable/GtkBuilder.html#BUILDER-UI
+[appdataxml]: https://wiki.gnome.org/Initiatives/GnomeGoals/AppDataGnomeSoftware
+[desktopfile]: https://specifications.freedesktop.org/desktop-entry-spec/
+[babelsetuptools]: http://babel.pocoo.org/en/latest/setup.html
+[babelcli]: http://babel.pocoo.org/en/latest/cmdline.html
+[babelpo]: http://babel.pocoo.org/en/latest/messages.html
+[pocontext]: https://www.gnu.org/software/gettext/manual/html_node/Contexts.html#Contexts

--- a/babelglade/extract.py
+++ b/babelglade/extract.py
@@ -30,15 +30,17 @@ def extract_glade(fileobj, keywords, comment_tags, options):
         tuples whose interpretation depends on ``funcname``.
     :rtype: iterator
 
-    Properties must be marked translatable="yes". Context and comments
-    attributes are respected. The yielded tuples are and returned as if
-    you used gettext() or pgettext() in C or Python code. In other
-    words, "gettext" or "pgettext" must be listed in ``keywords`` for
-    contextless or context-bearing strings to be translated. The
-    shorthand "_" and "C_" aliases from g18n.h are valid keywords too.
+    Properties must be marked translatable="yes". The "context" and
+    "comments" attributes are respected. The yielded tuples are returned
+    as if you used ``gettext()`` or ``pgettext()`` in C or Python code.
+    This means that translatable XML strings with contexts are are only
+    extracted if the string ``"pgettext"`` is present in ``keywords``,
+    and XML strings without context are only extracted if ``"gettext"``
+    is present. The shorthand ``_`` and ``C_`` aliases from ``g18n.h``
+    are valid ``keywords`` too.
 
-    Babel defaults to having "gettext" and "pgettext" in ``keywords``,
-    so you don't normally need to worry about this.
+    By default, Babel passes both these function names in ``keywords``,
+    amongst others, so you don't normally need to worry about this.
 
     See also:
 

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,14 @@
 
 from setuptools import setup
 
+
+def _slurp(name):
+    import os.path
+    path = os.path.join(os.path.dirname(__file__), name)
+    with open(path, encoding="utf-8") as fp:
+        return fp.read()
+
+
 setup(
     name    = 'BabelGladeExtractor',
     version = '0.7.0',
@@ -25,27 +33,8 @@ setup(
     maintainer = 'Tobias Mueller',
     maintainer_email = 'tobiasmue@gnome.org',
     description = 'Babel l10n support for Glade, GtkBuilder, and .desktop files',
-    long_description = """
-This package contains message catalog extractors for the following
-formats, extending Babel_ so it can handle them.
-
-    * The older "Glade v2" XML format;
-    * The new GtkBuilder-compatible "UI Definition XML" format used by
-      Glade_ 3.8 and above;
-    * The AppData XML dialect, because it's similar;
-    * FreeDesktop.org ".desktop" files.
-
-To make these formats translatable, install this package. Then in your
-own projects map some source and data files to the simple extractor
-names "glade" and "desktop" that are provided by this package. You can
-then use Babel's setuptools integration or its command line interface
-for routine i18n lifecycle tasks.
-
-.. _Babel: http://babel.pocoo.org/en/latest/index.html
-.. _Glade: https://glade.gnome.org/
-
-
-""",
+    long_description = _slurp("README.md"),
+    long_description_content_type = "text/markdown",
     url = 'https://github.com/GNOME-Keysign/babel-glade',
     keywords = ['PyGTK', 'PyGObject', 'Glade', 'GtkBuilder', 'gettext', 'Babel', 'I18n', 'L10n'],
     install_requires = ['Babel'],


### PR DESCRIPTION
Hi - thanks for merging #13! :bowing_man:

As promised, I updated the docs a bit, mostly just giving it a README. I noticed the [PyPi page](https://pypi.org/project/BabelGladeExtractor/) was a bit bare when I first started working with this package, and his is kinda the culmination of the work from #13. I definitely think a Getting Started section would be a good addition.

The README is now shared with `setup.py`, because apparently that's quite safe and good practice. You might need some extra bits in `setup_requires` to make it work, however: <https://packaging.python.org/guides/making-a-pypi-friendly-readme/>. I've not checked how it interoperates with twine uploads yet, but the README looks good on Github, if that's any help:sweat_smile: 

Let me know if these docs need any work, or if you notice any typos etc.